### PR TITLE
Refactor delay instance building

### DIFF
--- a/stackinawsgi/admin/__init__.py
+++ b/stackinawsgi/admin/__init__.py
@@ -1,0 +1,3 @@
+"""
+Stack-In-A-WSGI: Admin Module
+"""

--- a/stackinawsgi/admin/admin.py
+++ b/stackinawsgi/admin/admin.py
@@ -5,7 +5,7 @@ import logging
 
 from stackinabox.services.service import StackInABoxService
 
-from stackinawsgi.exceptions import *
+from stackinawsgi.exceptions import InvalidSessionId
 
 
 logger = logging.getLogger(__name__)

--- a/stackinawsgi/admin/admin.py
+++ b/stackinawsgi/admin/admin.py
@@ -1,0 +1,173 @@
+"""
+Stack-In-A-WSGI: StackInAWsgiAdmin
+"""
+from stackinabox.services.service import StackInABoxService
+
+
+class StackInAWsgiAdmin(StackInABoxService):
+    """
+    Stack-In-A-WSGI RESTful Admin API
+
+    :ivar :obj:`StackInAWsgiSessionManager` manager: session manager instance
+    :ivar text_type base_uri: base URI for accessing the session to which the
+        session uuid will be appended, http://localhost/stackinabox/ which
+        would result in http://localhost/stackinabox/<session-id>/
+    """
+
+    def __init__(self, session_manager, base_uri):
+        """
+        Initialize the Admin Interface
+        """
+        super(StackInAWsgiAdmin, self).__init__('admin')
+        self.manager = session_manager
+        self.base_uri = base_uri
+        self.register(
+            StackInABoxService.DELETE, '/', StackInAWsgiAdmin.remove_session
+        )
+        self.register(
+            StackInABoxService.POST, '/', StackInAWsgiAdmin.create_session
+        )
+        self.register(
+            StackInABoxService.PUT, '/', StackInAWsgiAdmin.reset_session
+        )
+        self.register(
+            StackInABoxService.GET, '/', StackInAWsgiAdmin.get_session_info
+        )
+
+    def helper_get_session_id(self, headers):
+        """
+        Helper to retrieve the session id or build a new one
+
+        :param dict headers: case insensitive header dictionary
+        :returns: text_type with the UUID of the session
+        """
+        session_id = None
+
+        if 'x-session-id' in headers:
+            session_id = headers['x-session-id']
+
+        return session_id
+
+    def helper_get_uri(self, session_id):
+        """
+        Helper to build the session URL
+
+        :param text_type session_id: session-id for URL is for
+        :returns: text_type, the URL for the session-id
+        """
+        return '{0}/{1}/'.format(
+            self.base_uri,
+            session_id
+        )
+
+    def create_session(self, request, uri, headers):
+        """
+        Create a new session
+
+        :param :obj:`Request` request: object containing the HTTP Request
+        :param text_type uri: the URI for the request per StackInABox
+        :param dict headers: case insensitive header dictionary
+
+        :returns: tuple for StackInABox HTTP Response
+
+        HTTP Request:
+            POST /admin/
+                X-Session-ID: (Optional) Session-ID to use when creating the
+                    new session
+
+        HTTP Responses:
+            201 - Session Created
+                X-Session-ID header contains the session-id
+                Location header contains the URL for the session
+        """
+        session_id = self.manager.create_session(
+            self.helper_get_session_id(
+                headers
+            )
+        )
+
+        headers['x-session-id'] = session_id
+        headers['location'] = self.helper_get_uri(
+            session_id
+        )
+        return (201, headers, '')
+
+    def remove_session(self, request, uri, headers):
+        """
+        Remove an existing session
+
+        :param :obj:`Request` request: object containing the HTTP Request
+        :param text_type uri: the URI for the request per StackInABox
+        :param dict headers: case insensitive header dictionary
+
+        :returns: tuple for StackInABox HTTP Response
+
+        HTTP Request:
+            DELETE /admin/
+                X-Session-ID: (Required) Session-ID to destroy
+
+        HTTP Responses:
+            204 - Session Destroyed
+            404 - Session-ID Not Found
+        """
+        try:
+            self.manager.remove_session(
+                self.helper_get_session_id(
+                    headers
+                )
+            )
+
+        except KeyError as ex:
+            return (404, headers, str(ex))
+        else:
+            return (204, headers, '')
+
+    def reset_session(self, request, uri, headers):
+        """
+        Reset the session; shortcut for removing and creating the session
+        while preserving the session-id.
+
+        :param :obj:`Request` request: object containing the HTTP Request
+        :param text_type uri: the URI for the request per StackInABox
+        :param dict headers: case insensitive header dictionary
+
+        :returns: tuple for StackInABox HTTP Response
+
+        HTTP Request:
+            PUT /admin/
+                X-Session-ID: (Required) Session-ID to reset
+
+        HTTP Responses:
+            205 - Session Reset
+            404 - Session-ID Not Found
+        """
+        try:
+            self.manager.reset_session(
+                self.helper_get_session_id(
+                    headers
+                )
+            )
+
+        except KeyError as ex:
+            return (404, headers, str(ex))
+        else:
+            return (205, headers, '')
+
+    def get_session_info(self, request, uri, headers):
+        """
+        Get Session Information - TBD
+
+        :param :obj:`Request` request: object containing the HTTP Request
+        :param text_type uri: the URI for the request per StackInABox
+        :param dict headers: case insensitive header dictionary
+
+        :returns: tuple for StackInABox HTTP Response
+
+        HTTP Request:
+            GET /admin/
+                X-Session-ID: (Optional) Session-ID to reset
+
+        HTTP Responses:
+            500 - Not Implemented
+        """
+        return (500, headers, 'Not Implemented')

--- a/stackinawsgi/admin/admin.py
+++ b/stackinawsgi/admin/admin.py
@@ -3,6 +3,8 @@ Stack-In-A-WSGI: StackInAWsgiAdmin
 """
 from stackinabox.services.service import StackInABoxService
 
+from stackinawsgi.exceptions import *
+
 
 class StackInAWsgiAdmin(StackInABoxService):
     """
@@ -117,7 +119,7 @@ class StackInAWsgiAdmin(StackInABoxService):
                 )
             )
 
-        except KeyError as ex:
+        except InvalidSessionId as ex:
             return (404, headers, str(ex))
         else:
             return (204, headers, '')
@@ -148,7 +150,7 @@ class StackInAWsgiAdmin(StackInABoxService):
                 )
             )
 
-        except KeyError as ex:
+        except InvalidSessionId as ex:
             return (404, headers, str(ex))
         else:
             return (205, headers, '')

--- a/stackinawsgi/exceptions.py
+++ b/stackinawsgi/exceptions.py
@@ -1,0 +1,15 @@
+"""
+Stack-In-A-WSGI: stackinawsgi.exceptions
+"""
+
+
+class InvalidSessionId(ValueError):
+    pass
+
+
+class InvalidServiceList(TypeError):
+    pass
+
+
+class NoServicesProvided(ValueError):
+    pass

--- a/stackinawsgi/exceptions.py
+++ b/stackinawsgi/exceptions.py
@@ -4,12 +4,21 @@ Stack-In-A-WSGI: stackinawsgi.exceptions
 
 
 class InvalidSessionId(ValueError):
+    """
+    Invalid Session ID as provided
+    """
     pass
 
 
 class InvalidServiceList(TypeError):
+    """
+    Service List has invalid entries
+    """
     pass
 
 
 class NoServicesProvided(ValueError):
+    """
+    Services were not provided
+    """
     pass

--- a/stackinawsgi/session/__init__.py
+++ b/stackinawsgi/session/__init__.py
@@ -1,0 +1,3 @@
+"""
+Stack-In-A-WSGI: Session Module
+"""

--- a/stackinawsgi/session/service.py
+++ b/stackinawsgi/session/service.py
@@ -1,0 +1,271 @@
+"""
+Stack-In-A-WSGI: StackInAWsgiSessionManager
+"""
+from __future__ import absolute_import
+
+import logging
+import re
+import uuid
+
+from stackinabox.services.service import StackInABoxService
+
+from .session import Session
+
+
+# Use a shared dictionary to try to ensure its availability under
+# various WSGI servers - e.g gunicorn, uwsgi.
+# note: using them multiprocessing functionality means the objects
+#       must be able to be pickled, which we can't guarantee. So
+#       we're stuck with threading.
+global_sessions = dict()
+
+
+logger = logging.getLogger(__name__)
+
+
+class StackInAWsgiSessionManager(StackInABoxService):
+    """
+    WSGI Session Manager for StackInABox
+
+    This is a special version of the StackInABoxService object that
+    overrides functionality in the base class that is not normally
+    overriden in order to provide access to the sessions.
+
+    This module does not provide an HTTP RESTful interface itself.
+    The :obj:`StackInAWsgiAdmin` uses this object to dynamically
+    manage the available sessions.
+
+    :ivar list services: a list of StackInABoxService objects that
+        have not yet been initialized.
+    """
+
+    def __init__(self):
+        """
+        Initialize the session manager
+        """
+        super(StackInAWsgiSessionManager, self).__init__('stackinabox')
+        logger.debug('Initializing Service Manager')
+        self.services = []
+
+    @staticmethod
+    def extract_session_id(uri):
+        """
+        Helper to extract a session-id from the URI
+
+        :param text_type uri: URI from the caller to extract the session-id
+            from.
+
+        :returns: None if session-id was not extractable, or a text_type
+            containing the session-id.
+        """
+        logger.debug(
+            'Attempting to extract session id from URI: {0}'.format(
+                uri
+            )
+        )
+        matcher = re.compile('^\/([\w-]+)\/.*')
+
+        matches = matcher.match(uri)
+        if matches:
+            session_id = matches.groups()[0]
+            logger.debug(
+                'Extracted session id {0} from {1}'.format(
+                    session_id,
+                    uri
+                )
+            )
+            return session_id
+
+        else:
+            logger.debug(
+                'Failed to find any session id in {0}'.format(
+                    uri
+                )
+            )
+            return None
+
+    @property
+    def base_url(self):
+        """
+        Base URI for the this module
+
+        :returns: text_type with the base URI
+        """
+        return self.__base_url
+
+    @base_url.setter
+    def base_url(self, value):
+        """
+        Setter for the Base URI
+
+        :param text_type value: base URI to use
+        """
+        self.__base_url = value
+
+    def request(self, method, request, uri, headers):
+        """
+        Override the standard handler in order to redirect to the
+        appropriate session.
+
+        :param :obj:`Request` request: object containing the HTTP Request
+        :param text_type uri: the URI for the request per StackInABox
+        :param dict headers: case insensitive header dictionary
+
+        HTTP Request:
+            <METHOD> /stackinabox/<session-id>/...
+
+            Does not provide any support directly on /stackinabox/
+
+        HTTP Response:
+            593 - Session-ID was not present in the URI
+            594 - Invalid Session-ID
+
+            Other responses are from StackInABox or the session.
+        """
+        # uri = /<session-id>/url/for/session/handler
+        # lookup <session-id> in the global 'global_sessions'
+        session_id = self.extract_session_id(uri)
+        if session_id is None:
+            logger.debug(
+                'Failed to locate session id in {0}'.format(
+                    uri
+                )
+            )
+            return (593, headers, 'StackInAWSGI - Missing Session')
+
+        logger.debug(
+            'Operating with Session Id {0}'.format(
+                session_id
+            )
+        )
+
+        if session_id in global_sessions:
+            logger.debug(
+                'Located session id {0}'.format(
+                    session_id
+                )
+            )
+            session_uri = uri[1:]
+
+            logger.debug(
+                'Updated URI from {0} to {1}'.format(
+                    uri,
+                    session_uri
+                )
+            )
+
+            # Let the session handle the request
+            return global_sessions[session_id].call(
+                method,
+                request,
+                session_uri,
+                headers
+            )
+
+        else:
+            logger.debug(
+                'Failed to find a matching session for session id {0}'.format(
+                    session_id
+                )
+            )
+            # Report an unknown session
+            return (594, headers, 'StackInAWSGI - Unknown Session')
+
+    def register_service(self, service):
+        """
+        Add the service to the global list of services to be instantiated into
+        each newly created session
+
+        :param object-type service: an uninstantiated object what is derived
+            from :obj:`StackInABoxService`. When a session is created then it
+            will be instantiated and added to the StackInABox Service.
+        """
+        logger.debug(
+            'Adding service'
+        )
+        self.services.append(service)
+
+    def reset_session(self, session_id):
+        """
+        Recreate the session so it starts from scratch
+
+        :raises: KeyError if the Session ID is not found
+        """
+        logger.debug(
+            'Resetting Session {0}'.format(
+                session_id
+            )
+        )
+        if session_id in global_sessions:
+            logger.debug(
+                'Removing Session {0}'.format(
+                    session_id
+                )
+            )
+            del global_sessions[session_id]
+            logger.debug(
+                'Re-creating Session {0}'.format(
+                    session_id
+                )
+            )
+            self.create_session(session_id=session_id)
+            logger.debug(
+                'Reset of Session {0} Completed'.format(
+                    session_id
+                )
+            )
+
+        else:
+            raise KeyError('Invalid Session ID')
+
+    def create_session(self, session_id=None):
+        """
+        Create a new session and return its uuid
+
+        :param text_type session_id: optional session id to create, if not
+            provided then one will be created.
+
+        :returns: text_type with the session id
+        """
+        logger.debug(
+            'Requesting creation of session. Optional Session Id: {0}'.format(
+                session_id
+            )
+        )
+        if session_id is None:
+            logger.debug(
+                'Creating new session id'
+            )
+            session_id = str(uuid.uuid4())
+
+        logger.debug(
+            'Session id: {0}'.format(
+                session_id
+            )
+        )
+
+        if session_id not in global_sessions:
+            logger.debug(
+                'Creating new session for session id {0}'.format(
+                    session_id
+                )
+            )
+            global_sessions[session_id] = Session(
+                session_id,
+                self.services
+            )
+
+        return session_id
+
+    def remove_session(self, session_id):
+        """
+        Remove the session
+
+        :param text_type session_id: session id to remove
+
+        :raises: Key Error if session id is not found
+        """
+        if session_id in global_sessions:
+            del global_sessions[session_id]
+        else:
+            raise KeyError('Invalid Session ID')

--- a/stackinawsgi/session/service.py
+++ b/stackinawsgi/session/service.py
@@ -9,7 +9,9 @@ import uuid
 
 from stackinabox.services.service import StackInABoxService
 
-from stackinawsgi.exceptions import *
+from stackinawsgi.exceptions import (
+    InvalidSessionId
+)
 from .session import Session
 
 

--- a/stackinawsgi/session/session.py
+++ b/stackinawsgi/session/session.py
@@ -1,0 +1,177 @@
+"""
+Stack-In-A-WSGI Session Module
+"""
+from __future__ import absolute_import
+
+import logging
+from threading import Lock
+
+from stackinabox.stack import StackInABox
+
+
+logger = logging.getLogger(__name__)
+
+
+class Session(object):
+    """
+    Wrapper for StackInABox to be safely use it in a multi-request
+    supported environment.
+    """
+
+    def __init__(self, session_id, services):
+        """
+        Initialize the wrapper
+
+        :ivar str session_id: session-id for the StackInABox instance
+        :ivar list services: list of non-instances services
+        :ivar Lock lock: Lock for ensuring StackInABox is safely used
+        :ivar StackInABox stack: StackInABox instance being managed
+        """
+        logger.debug(
+            'Creating wrapper for session: {0}'.format(session_id)
+        )
+        logger.debug(
+            'Session {0} has {1} services'.format(
+                session_id,
+                len(services)
+            )
+        )
+        self.session_id = session_id
+        self.services = services
+        self.lock = Lock()
+        self.stack = StackInABox()
+        self.stack.base_url = self.session_id
+        self.session_id
+        self.init_services()
+
+    def init_services(self):
+        """
+        Initialize the StackInABox instance with the services
+        """
+        for service in self.services:
+            svc = service()
+            logger.debug(
+                'Session {0}: Initializing service {1}'.format(
+                    self.session_id,
+                    svc.name
+                )
+            )
+            self.stack.register(svc)
+
+    @property
+    def base_url(self):
+        """
+        Pass-thru to the StackInABox instance's base_url property
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            return self.stack.base_url
+
+    @base_url.setter
+    def base_url(self, value):
+        """
+        Pass-thru to the StackInABox instance's base_url property
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            self.stack.base_url = value
+
+    def reset(self):
+        """
+        Reset the StackInABox instance to the initial state by
+        resetting the instance then re-registering all the services.
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            logger.debug(
+                'Session {0}: Acquired lock'.format(
+                    self.session_id
+                )
+            )
+
+            self.stack.reset()
+            self.init_services()
+
+    def call(self, *args, **kwargs):
+        """
+        Wrapper to same in the StackInABox instance
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            logger.debug(
+                'Session {0}: Acquired lock'.format(
+                    self.session_id
+                )
+            )
+
+            return self.stack.call(*args, **kwargs)
+
+    def try_handle_route(self, *args, **kwargs):
+        """
+        Wrapper to same in the StackInABox instance
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            logger.debug(
+                'Session {0}: Acquired lock'.format(
+                    self.session_id
+                )
+            )
+
+            return self.stack.try_handle_route(*args, **kwargs)
+
+    def request(self, *args, **kwargs):
+        """
+        Wrapper to same in the StackInABox instance
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            logger.debug(
+                'Session {0}: Acquired lock'.format(
+                    self.session_id
+                )
+            )
+
+            return self.stack.request(*args, **kwargs)
+
+    def sub_request(self, *args, **kwargs):
+        """
+        Pass-thru to the StackInABox instance's sub_request
+        """
+        logger.debug(
+            'Session {0}: Waiting for lock'.format(
+                self.session_id
+            )
+        )
+        with self.lock:
+            logger.debug(
+                'Session {0}: Acquired lock'.format(
+                    self.session_id
+                )
+            )
+
+            return self.stack.sub_request(*args, **kwargs)

--- a/stackinawsgi/session/session.py
+++ b/stackinawsgi/session/session.py
@@ -8,6 +8,8 @@ from threading import Lock
 
 from stackinabox.stack import StackInABox
 
+from stackinawsgi.exceptions import *
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,18 +32,27 @@ class Session(object):
         logger.debug(
             'Creating wrapper for session: {0}'.format(session_id)
         )
+        if session_id is None:
+            raise InvalidSessionId('Session ID cannot be none')
+
+        if services is None:
+            raise InvalidServiceList('Services is empty')
+
         logger.debug(
             'Session {0} has {1} services'.format(
                 session_id,
                 len(services)
             )
         )
+
+        if len(services) == 0:
+            raise NoServicesProvided('No services configured')
+
         self.session_id = session_id
         self.services = services
         self.lock = Lock()
         self.stack = StackInABox()
         self.stack.base_url = self.session_id
-        self.session_id
         self.init_services()
 
     def init_services(self):

--- a/stackinawsgi/session/session.py
+++ b/stackinawsgi/session/session.py
@@ -8,7 +8,11 @@ from threading import Lock
 
 from stackinabox.stack import StackInABox
 
-from stackinawsgi.exceptions import *
+from stackinawsgi.exceptions import (
+    InvalidSessionId,
+    InvalidServiceList,
+    NoServicesProvided
+)
 
 
 logger = logging.getLogger(__name__)

--- a/stackinawsgi/test/test_admin_admin.py
+++ b/stackinawsgi/test/test_admin_admin.py
@@ -3,15 +3,11 @@ Stack-In-A-WSGI: stackinawsgi.admin.admin.StackInAWsgiSessionManager
 """
 
 import unittest
-import uuid
-
-import mock
 
 from stackinabox.services.service import StackInABoxService
 from stackinabox.services.hello import HelloService
 
 from stackinawsgi.admin.admin import StackInAWsgiAdmin
-from stackinawsgi.exceptions import *
 from stackinawsgi.session.service import (
     global_sessions,
     StackInAWsgiSessionManager
@@ -19,6 +15,7 @@ from stackinawsgi.session.service import (
 from stackinawsgi.wsgi.request import Request
 from stackinawsgi.wsgi.response import Response
 from stackinawsgi.test.helpers import make_environment
+
 
 class TestSessionManager(unittest.TestCase):
     """
@@ -45,7 +42,7 @@ class TestSessionManager(unittest.TestCase):
         """
         test basic construction of the admin interface
         """
-        admin = StackInAWsgiAdmin(self.manager, self.base_uri) 
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
         self.assertIsInstance(admin, StackInABoxService)
         self.assertEqual(id(self.manager), id(admin.manager))
         self.assertTrue(admin.base_uri.startswith(self.base_uri))
@@ -68,7 +65,6 @@ class TestSessionManager(unittest.TestCase):
         test extracting the session-id from the headers
         """
         admin = StackInAWsgiAdmin(self.manager, self.base_uri)
-        session_id = 'some-session-id'
         headers = {}
 
         extracted_session_id = admin.helper_get_session_id(headers)

--- a/stackinawsgi/test/test_admin_admin.py
+++ b/stackinawsgi/test/test_admin_admin.py
@@ -1,7 +1,6 @@
 """
 Stack-In-A-WSGI: stackinawsgi.admin.admin.StackInAWsgiSessionManager
 """
-
 import unittest
 
 from stackinabox.services.service import StackInABoxService
@@ -46,6 +45,16 @@ class TestSessionManager(unittest.TestCase):
         self.assertIsInstance(admin, StackInABoxService)
         self.assertEqual(id(self.manager), id(admin.manager))
         self.assertTrue(admin.base_uri.startswith(self.base_uri))
+
+    def test_construction_alternate_url(self):
+        """
+        test basic construction of the admin interface
+        """
+        base_uri = '/hello'
+        admin = StackInAWsgiAdmin(self.manager, base_uri)
+        self.assertIsInstance(admin, StackInABoxService)
+        self.assertEqual(id(self.manager), id(admin.manager))
+        self.assertTrue(admin.base_uri.startswith(base_uri[1:]))
 
     def test_helper_get_session_id(self):
         """

--- a/stackinawsgi/test/test_admin_admin.py
+++ b/stackinawsgi/test/test_admin_admin.py
@@ -1,0 +1,344 @@
+"""
+Stack-In-A-WSGI: stackinawsgi.admin.admin.StackInAWsgiSessionManager
+"""
+
+import unittest
+import uuid
+
+import mock
+
+from stackinabox.services.service import StackInABoxService
+from stackinabox.services.hello import HelloService
+
+from stackinawsgi.admin.admin import StackInAWsgiAdmin
+from stackinawsgi.exceptions import *
+from stackinawsgi.session.service import (
+    global_sessions,
+    StackInAWsgiSessionManager
+)
+from stackinawsgi.wsgi.request import Request
+from stackinawsgi.wsgi.response import Response
+from stackinawsgi.test.helpers import make_environment
+
+class TestSessionManager(unittest.TestCase):
+    """
+    Test the interaction of StackInAWSGI's Session Manager
+    """
+
+    def setUp(self):
+        """
+        configure env for the test
+        """
+        self.manager = StackInAWsgiSessionManager()
+        self.manager.register_service(HelloService)
+        self.base_uri = 'test://testing-url'
+
+    def tearDown(self):
+        """
+        clean up after the test
+        """
+        keys = tuple(global_sessions.keys())
+        for k in keys:
+            del global_sessions[k]
+
+    def test_construction(self):
+        """
+        test basic construction of the admin interface
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri) 
+        self.assertIsInstance(admin, StackInABoxService)
+        self.assertEqual(id(self.manager), id(admin.manager))
+        self.assertTrue(admin.base_uri.startswith(self.base_uri))
+
+    def test_helper_get_session_id(self):
+        """
+        test extracting the session-id from the headers
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+        session_id = 'some-session-id'
+        headers = {
+            'x-session-id': session_id
+        }
+
+        extracted_session_id = admin.helper_get_session_id(headers)
+        self.assertEqual(session_id, extracted_session_id)
+
+    def test_helper_get_session_id_no_session_id(self):
+        """
+        test extracting the session-id from the headers
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+        session_id = 'some-session-id'
+        headers = {}
+
+        extracted_session_id = admin.helper_get_session_id(headers)
+        self.assertIsNone(extracted_session_id)
+
+    def test_helper_get_uri(self):
+        """
+        test building the URI
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+        session_id = 'some-session-id'
+        expected_uri = '{0}/{1}/'.format(self.base_uri, session_id)
+        result_uri = admin.helper_get_uri(session_id)
+        self.assertEqual(expected_uri, result_uri)
+
+    def test_session_creation(self):
+        """
+        test creating a new session
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='POST',
+            path=uri[1:]
+        )
+        request = Request(environment)
+        response = Response()
+
+        result = admin.create_session(
+            request,
+            uri,
+            response.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 201)
+        # validate header entries
+        self.assertIn('x-session-id', response.headers)
+        self.assertIn('location', response.headers)
+
+        # validate x-session-id
+        session_id = response.headers['x-session-id']
+        self.assertIn(session_id, global_sessions)
+
+        # validate location
+        self.assertEqual(
+            '{0}/{1}/'.format(self.base_uri, session_id),
+            response.headers['location']
+        )
+
+    def test_session_creation_with_session_id(self):
+        """
+        test creating a new session with a session-id
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        session_id = 'my-session-id'
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='POST',
+            path=uri[1:],
+            headers={
+                'x-session-id': session_id
+            }
+        )
+        request = Request(environment)
+        self.assertIn('x-session-id', request.headers)
+        self.assertEqual(session_id, request.headers['x-session-id'])
+        response = Response()
+
+        result = admin.create_session(
+            request,
+            uri,
+            request.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 201)
+        # validate header entries
+        self.assertIn('x-session-id', response.headers)
+        self.assertIn('location', response.headers)
+
+        # validate x-session-id
+        extracted_session_id = response.headers['x-session-id']
+        self.assertEqual(session_id, extracted_session_id)
+        self.assertIn(extracted_session_id, global_sessions)
+
+        # validate location
+        self.assertEqual(
+            '{0}/{1}/'.format(self.base_uri, extracted_session_id),
+            response.headers['location']
+        )
+
+    def test_session_remove(self):
+        """
+        test removing a session
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        session_id = self.manager.create_session()
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='DELETE',
+            path=uri[1:],
+            headers={
+                'x-session-id': session_id
+            }
+        )
+        request = Request(environment)
+        self.assertIn('x-session-id', request.headers)
+        self.assertEqual(session_id, request.headers['x-session-id'])
+        response = Response()
+
+        result = admin.remove_session(
+            request,
+            uri,
+            request.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 204)
+
+    def test_session_remove_invalid_session_id(self):
+        """
+        test removing a session with an invalid session id
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        session_id = 'my-session-id'
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='DELETE',
+            path=uri[1:],
+            headers={
+                'x-session-id': session_id
+            }
+        )
+        request = Request(environment)
+        self.assertIn('x-session-id', request.headers)
+        self.assertEqual(session_id, request.headers['x-session-id'])
+        response = Response()
+
+        result = admin.remove_session(
+            request,
+            uri,
+            request.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 404)
+
+    def test_session_reset(self):
+        """
+        test resetting a session
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        session_id = self.manager.create_session()
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='PUT',
+            path=uri[1:],
+            headers={
+                'x-session-id': session_id
+            }
+        )
+        request = Request(environment)
+        self.assertIn('x-session-id', request.headers)
+        self.assertEqual(session_id, request.headers['x-session-id'])
+        response = Response()
+
+        result = admin.reset_session(
+            request,
+            uri,
+            request.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 205)
+
+    def test_session_reset_invalid_session_id(self):
+        """
+        test resetting a session with an invalid session id
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        session_id = 'my-session-id'
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='PUT',
+            path=uri[1:],
+            headers={
+                'x-session-id': session_id
+            }
+        )
+        request = Request(environment)
+        self.assertIn('x-session-id', request.headers)
+        self.assertEqual(session_id, request.headers['x-session-id'])
+        response = Response()
+
+        result = admin.reset_session(
+            request,
+            uri,
+            request.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 404)
+
+    def test_get_session_info(self):
+        """
+        test resetting a session with an invalid session id
+        """
+        admin = StackInAWsgiAdmin(self.manager, self.base_uri)
+
+        session_id = 'my-session-id'
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='PUT',
+            path=uri[1:],
+            headers={
+                'x-session-id': session_id
+            }
+        )
+        request = Request(environment)
+        self.assertIn('x-session-id', request.headers)
+        self.assertEqual(session_id, request.headers['x-session-id'])
+        response = Response()
+
+        result = admin.get_session_info(
+            request,
+            uri,
+            request.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        # validate response
+        self.assertEqual(response.status, 500)

--- a/stackinawsgi/test/test_session_service.py
+++ b/stackinawsgi/test/test_session_service.py
@@ -5,12 +5,12 @@ Stack-In-A-WSGI: stackinawsgi.session.service.StackInAWsgiSessionManager
 import unittest
 import uuid
 
-import mock
-
 from stackinabox.services.service import StackInABoxService
 from stackinabox.services.hello import HelloService
 
-from stackinawsgi.exceptions import *
+from stackinawsgi.exceptions import (
+    InvalidSessionId
+)
 from stackinawsgi.session.service import (
     global_sessions,
     StackInAWsgiSessionManager
@@ -18,6 +18,7 @@ from stackinawsgi.session.service import (
 from stackinawsgi.wsgi.request import Request
 from stackinawsgi.wsgi.response import Response
 from stackinawsgi.test.helpers import make_environment
+
 
 class TestSessionManager(unittest.TestCase):
     """
@@ -224,7 +225,6 @@ class TestSessionManager(unittest.TestCase):
         """
         manager = StackInAWsgiSessionManager()
         manager.register_service(HelloService)
-        session_id = manager.create_session()
 
         uri = u'/some-invalid-id/hello/'
         environment = make_environment(
@@ -254,7 +254,6 @@ class TestSessionManager(unittest.TestCase):
         """
         manager = StackInAWsgiSessionManager()
         manager.register_service(HelloService)
-        session_id = manager.create_session()
 
         uri = u'/'
         environment = make_environment(

--- a/stackinawsgi/test/test_session_service.py
+++ b/stackinawsgi/test/test_session_service.py
@@ -208,7 +208,7 @@ class TestSessionManager(unittest.TestCase):
             request.method,
             request,
             uri,
-            response.headers
+            request.headers
         )
         response.from_stackinabox(
             result[0],
@@ -239,7 +239,7 @@ class TestSessionManager(unittest.TestCase):
             request.method,
             request,
             uri,
-            response.headers
+            request.headers
         )
         response.from_stackinabox(
             result[0],
@@ -269,7 +269,7 @@ class TestSessionManager(unittest.TestCase):
             request.method,
             request,
             uri,
-            response.headers
+            request.headers
         )
         response.from_stackinabox(
             result[0],

--- a/stackinawsgi/test/test_session_service.py
+++ b/stackinawsgi/test/test_session_service.py
@@ -1,0 +1,279 @@
+"""
+Stack-In-A-WSGI: stackinawsgi.session.service.StackInAWsgiSessionManager
+"""
+
+import unittest
+import uuid
+
+import mock
+
+from stackinabox.services.service import StackInABoxService
+from stackinabox.services.hello import HelloService
+
+from stackinawsgi.exceptions import *
+from stackinawsgi.session.service import (
+    global_sessions,
+    StackInAWsgiSessionManager
+)
+from stackinawsgi.wsgi.request import Request
+from stackinawsgi.wsgi.response import Response
+from stackinawsgi.test.helpers import make_environment
+
+class TestSessionManager(unittest.TestCase):
+    """
+    Test the interaction of StackInAWSGI's Session Manager
+    """
+
+    def setUp(self):
+        """
+        configure env for the test
+        """
+        self.session_id = str(uuid.uuid4())
+
+    def tearDown(self):
+        """
+        clean up after the test
+        """
+        keys = tuple(global_sessions.keys())
+        for k in keys:
+            del global_sessions[k]
+
+    def test_session_id_extraction_with_session(self):
+        """
+        test extracting an ID from a URI with session
+        """
+        self.assertEqual(
+            self.session_id,
+            StackInAWsgiSessionManager.extract_session_id(
+                '/{0}/'.format(
+                    self.session_id
+                )
+            )
+        )
+
+    def test_session_id_extraction_without_session(self):
+        """
+        test extracting an ID from a URI without session
+        """
+        self.assertIsNone(
+            StackInAWsgiSessionManager.extract_session_id(
+                '/'
+            )
+        )
+
+    def test_construction(self):
+        """
+        test basic construction of the manager
+        """
+        manager = StackInAWsgiSessionManager()
+
+        self.assertIsInstance(manager, StackInABoxService)
+        self.assertTrue(hasattr(manager, 'services'))
+        self.assertEqual(len(manager.services), 0)
+
+    def test_base_url(self):
+        """
+        Test Base URL
+        """
+        def validate(s, b):
+            self.assertEqual(
+                b,
+                s.base_url
+            )
+
+        manager = StackInAWsgiSessionManager()
+
+        new_base_url = 'howdy-from-the-test'
+        manager.base_url = new_base_url
+        validate(manager, new_base_url)
+
+    def test_register(self):
+        """
+        test registering a service modifies the global services
+        """
+        manager = StackInAWsgiSessionManager()
+
+        self.assertEqual(len(manager.services), 0)
+        manager.register_service(HelloService)
+        self.assertEqual(len(manager.services), 1)
+
+    def test_create_session_no_session_id(self):
+        """
+        test creating a session
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+
+        session_id = manager.create_session()
+        self.assertIn(session_id, global_sessions)
+
+    def test_create_session_with_session_id(self):
+        """
+        test creating a session with a session id
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+
+        existing_session_id = 'christopher-columbus'
+        session_id = manager.create_session(
+            session_id=existing_session_id
+        )
+        self.assertEqual(
+            existing_session_id,
+            session_id
+        )
+        self.assertIn(session_id, global_sessions)
+
+    def test_create_an_existing_session(self):
+        """
+        test creating a session using an existing session id
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+
+        session_id = manager.create_session()
+        self.assertIn(session_id, global_sessions)
+
+        new_session_id = manager.create_session(
+            session_id=session_id
+        )
+        self.assertEqual(
+            session_id,
+            new_session_id
+        )
+        self.assertIn(session_id, global_sessions)
+
+    def test_reset_session(self):
+        """
+        test reseting a session
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+
+        session_id = manager.create_session()
+        self.assertIn(session_id, global_sessions)
+
+        manager.reset_session(session_id)
+        self.assertIn(session_id, global_sessions)
+
+    def test_reset_session_invalid_session_id(self):
+        """
+        test reseting an invalid session id
+        """
+        manager = StackInAWsgiSessionManager()
+
+        with self.assertRaises(InvalidSessionId):
+            manager.reset_session('some invalid id')
+
+    def test_remove_session(self):
+        """
+        test removing a session
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+
+        session_id = manager.create_session()
+        self.assertIn(session_id, global_sessions)
+
+        manager.remove_session(session_id)
+        self.assertNotIn(session_id, global_sessions)
+
+    def test_remove_invalid_session(self):
+        """
+        test removing an invalid session id
+        """
+        manager = StackInAWsgiSessionManager()
+
+        with self.assertRaises(InvalidSessionId):
+            manager.remove_session('some invalid id')
+
+    def test_request(self):
+        """
+        test making a request into a session
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+        session_id = manager.create_session()
+
+        uri = u'/{0}/hello/'.format(session_id)
+        environment = make_environment(
+            self,
+            method='GET',
+            path=uri[1:]
+        )
+        request = Request(environment)
+        response = Response()
+
+        result = manager.request(
+            request.method,
+            request,
+            uri,
+            response.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, 'Hello')
+
+    def test_request_invalid_session(self):
+        """
+        test trying to find a non-existent session
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+        session_id = manager.create_session()
+
+        uri = u'/some-invalid-id/hello/'
+        environment = make_environment(
+            self,
+            method='GET',
+            path=uri[1:]
+        )
+        request = Request(environment)
+        response = Response()
+
+        result = manager.request(
+            request.method,
+            request,
+            uri,
+            response.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        self.assertEqual(response.status, 594)
+
+    def test_request_no_session_in_url(self):
+        """
+        test failing to extract a session from the uri
+        """
+        manager = StackInAWsgiSessionManager()
+        manager.register_service(HelloService)
+        session_id = manager.create_session()
+
+        uri = u'/'
+        environment = make_environment(
+            self,
+            method='GET',
+            path=uri[1:]
+        )
+        request = Request(environment)
+        response = Response()
+
+        result = manager.request(
+            request.method,
+            request,
+            uri,
+            response.headers
+        )
+        response.from_stackinabox(
+            result[0],
+            result[1],
+            result[2]
+        )
+        self.assertEqual(response.status, 593)

--- a/stackinawsgi/test/test_session_session.py
+++ b/stackinawsgi/test/test_session_session.py
@@ -1,0 +1,192 @@
+"""
+Stack-In-A-WSGI: stackinawsgi.session.session.Session testing
+"""
+import unittest
+from threading import Lock
+import uuid
+
+import ddt
+import mock
+
+from stackinabox.stack import StackInABox
+from stackinabox.services.hello import HelloService
+
+from stackinawsgi.exceptions import *
+from stackinawsgi.session.session import Session
+
+
+@ddt.ddt
+class TestSessionSession(unittest.TestCase):
+    """
+    Test the interaction of StackInAWSGI's Session object
+    """
+
+    def setUp(self):
+        """
+        configure env for the test
+        """
+        self.session_id = str(uuid.uuid4())
+        self.services = [HelloService]
+
+    def tearDown(self):
+        """
+        clean up after the test
+        """
+        pass
+
+    def test_contstruction_invalid_session_id(self):
+        """
+        Test construction of a session object with an invalid session id
+        """
+        with self.assertRaises(InvalidSessionId):
+            Session(None, [HelloService])
+
+    @ddt.unpack
+    @ddt.data(
+        ([], NoServicesProvided),
+        (None, InvalidServiceList),
+    )
+    def test_construction_with_invalid_services(self, invalid_service_value,
+            expected_exception):
+        """
+        test construction of a session object with a series of invalid values
+        """
+        with self.assertRaises(expected_exception):
+            Session('invalid-services-list-testing', invalid_service_value)
+
+    def test_construction(self):
+        """
+        Test successful construction and init_services()
+        """
+
+        session = Session(self.session_id, self.services)
+        self.assertEqual(self.session_id, session.session_id)
+        self.assertEqual(self.services, session.services)
+        self.assertTrue(isinstance(session.lock, type(Lock())))
+        self.assertTrue(isinstance(session.stack, StackInABox))
+        self.assertEqual(session.session_id, session.stack.base_url)
+        self.assertEqual(len(self.services), len(session.stack.services))
+        tuple_services = tuple(self.services)
+        for _, v in session.stack.services.items():
+            _, svc = v
+            self.assertIsInstance(svc, tuple_services)
+
+    def test_base_url(self):
+        """
+        Test Base URL
+        """
+        def validate(s, b):
+            self.assertEqual(
+                b,
+                s.base_url
+            )
+            self.assertEqual(
+                b,
+                s.stack.base_url
+            )
+
+        session = Session(self.session_id, self.services)
+        validate(session, self.session_id)
+
+        new_base_url = 'howdy-from-the-test'
+        session.base_url = new_base_url
+        validate(session, new_base_url)
+
+    def test_reset(self):
+        """
+        test resetting
+        """
+        def get_service_instance_info(s):
+            list_ids = {}
+            for k, v in s.stack.services.items():
+                m, svc = v
+                list_ids[(k, m)] = id(svc)
+            return list_ids
+
+        session = Session(self.session_id, self.services)
+
+        original_session_ids = get_service_instance_info(session)
+
+        session.reset()
+
+        new_session_ids = get_service_instance_info(session)
+
+        for k, v in original_session_ids.items():
+            self.assertIn(k, new_session_ids)
+            self.assertNotEqual(v, new_session_ids[k])
+
+    def test_call(self):
+        """
+        test calling into the session
+        """
+        mock_session_stack_call = mock.Mock()
+        mock_session_stack_call.return_value = True
+
+        session = Session(self.session_id, self.services)
+        session.stack.call = mock_session_stack_call
+
+        self.assertEqual(mock_session_stack_call.call_count, 0)
+        self.assertTrue(session.call('hello', 'world'))
+        self.assertTrue(mock_session_stack_call.called)
+        self.assertEqual(mock_session_stack_call.call_count, 1)
+        self.assertEqual(
+            mock_session_stack_call.call_args,
+            (('hello', 'world'),)
+        )
+
+    def test_try_handle_route(self):
+        """
+        test calling the session request handler
+        """
+        mock_session_try_handle_route = mock.Mock()
+        mock_session_try_handle_route.return_value = True
+
+        session = Session(self.session_id, self.services)
+        session.stack.try_handle_route = mock_session_try_handle_route
+
+        self.assertEqual(mock_session_try_handle_route.call_count, 0)
+        self.assertTrue(session.try_handle_route('hello', 'world'))
+        self.assertTrue(mock_session_try_handle_route.called)
+        self.assertEqual(mock_session_try_handle_route.call_count, 1)
+        self.assertEqual(
+            mock_session_try_handle_route.call_args,
+            (('hello', 'world'),)
+        )
+
+    def test_request(self):
+        """
+        test calling the session request handler
+        """
+        mock_session_request = mock.Mock()
+        mock_session_request.return_value = True
+
+        session = Session(self.session_id, self.services)
+        session.stack.request = mock_session_request
+
+        self.assertEqual(mock_session_request.call_count, 0)
+        self.assertTrue(session.request('hello', 'world'))
+        self.assertTrue(mock_session_request.called)
+        self.assertEqual(mock_session_request.call_count, 1)
+        self.assertEqual(
+            mock_session_request.call_args,
+            (('hello', 'world'),)
+        )
+
+    def test_sub_request(self):
+        """
+        test calling the session sub_request handler
+        """
+        mock_session_sub_request = mock.Mock()
+        mock_session_sub_request.return_value = True
+
+        session = Session(self.session_id, self.services)
+        session.stack.sub_request = mock_session_sub_request
+
+        self.assertEqual(mock_session_sub_request.call_count, 0)
+        self.assertTrue(session.sub_request('hello', 'world'))
+        self.assertTrue(mock_session_sub_request.called)
+        self.assertEqual(mock_session_sub_request.call_count, 1)
+        self.assertEqual(
+            mock_session_sub_request.call_args,
+            (('hello', 'world'),)
+        )

--- a/stackinawsgi/test/test_session_session.py
+++ b/stackinawsgi/test/test_session_session.py
@@ -11,7 +11,11 @@ import mock
 from stackinabox.stack import StackInABox
 from stackinabox.services.hello import HelloService
 
-from stackinawsgi.exceptions import *
+from stackinawsgi.exceptions import (
+    InvalidSessionId,
+    InvalidServiceList,
+    NoServicesProvided
+)
 from stackinawsgi.session.session import Session
 
 
@@ -47,7 +51,7 @@ class TestSessionSession(unittest.TestCase):
         (None, InvalidServiceList),
     )
     def test_construction_with_invalid_services(self, invalid_service_value,
-            expected_exception):
+                                                expected_exception):
         """
         test construction of a session object with a series of invalid values
         """

--- a/stackinawsgi/test/test_wsgi_app.py
+++ b/stackinawsgi/test/test_wsgi_app.py
@@ -90,6 +90,9 @@ class TestWsgiApp(unittest.TestCase):
         with self.assertRaises(TypeError):
             App([InvalidService()])
 
+        with self.assertRaises(TypeError):
+            App([InvalidService])
+
     def test_reset(self):
         """
         Reset a StackInAWSGI

--- a/stackinawsgi/test/test_wsgi_app.py
+++ b/stackinawsgi/test/test_wsgi_app.py
@@ -28,14 +28,25 @@ class TestWsgiApp(unittest.TestCase):
         Test setup
         """
         self.apps = [
-            HelloService()
+            HelloService
         ]
 
     def tearDown(self):
         """
         Test Teardown
         """
-        pass
+        StackInABox.reset_services()
+
+    def helper_make_session(self, the_app):
+        """
+        """
+        self.session_id = the_app.stack_service.create_session()
+        self.session_uri = the_app.admin_service.helper_get_uri(
+            self.session_id
+        )
+        self.session_id_uri = u'/stackinabox/{0}'.format(
+            self.session_id
+        )
 
     def test_construction(self):
         """
@@ -44,7 +55,7 @@ class TestWsgiApp(unittest.TestCase):
         the_app = App()
         self.assertTrue(hasattr(the_app, 'stackinabox'))
         self.assertIsInstance(the_app.stackinabox, StackInABox)
-        self.assertEqual(len(the_app.stackinabox.services), 0)
+        self.assertEqual(len(the_app.stack_service.services), 0)
 
     def test_construction_with_service(self):
         """
@@ -53,12 +64,23 @@ class TestWsgiApp(unittest.TestCase):
         the_app = App(self.apps)
         self.assertTrue(hasattr(the_app, 'stackinabox'))
         self.assertIsInstance(the_app.stackinabox, StackInABox)
-        self.assertEqual(len(the_app.stackinabox.services), 1)
+        self.assertEqual(len(the_app.stack_service.services), 1)
         for an_app in self.apps:
-            self.assertIn(an_app.name, the_app.stackinabox.services)
-            self.assertEqual(
-                an_app,
-                the_app.stackinabox.services[an_app.name][1]
+            self.assertTrue(
+                True in [x == an_app for x in the_app.stack_service.services]
+            )
+
+    def test_construction_with_service_non_iterable(self):
+        """
+        Basic App creation with a StackInABoxService
+        """
+        the_app = App(self.apps[0])
+        self.assertTrue(hasattr(the_app, 'stackinabox'))
+        self.assertIsInstance(the_app.stackinabox, StackInABox)
+        self.assertEqual(len(the_app.stack_service.services), 1)
+        for an_app in self.apps:
+            self.assertTrue(
+                True in [x == an_app for x in the_app.stack_service.services]
             )
 
     def test_construction_with_invalid_service(self):
@@ -75,9 +97,10 @@ class TestWsgiApp(unittest.TestCase):
         the_app = App(self.apps)
         self.assertTrue(hasattr(the_app, 'stackinabox'))
         self.assertIsInstance(the_app.stackinabox, StackInABox)
-        self.assertEqual(len(the_app.stackinabox.services), 1)
-        the_app.ResetStackInABox()
-        self.assertEqual(len(the_app.stackinabox.services), 0)
+        self.assertEqual(len(the_app.stack_service.services), 1)
+        self.helper_make_session(the_app)
+        the_app.ResetStackInABox(self.session_id)
+        self.assertEqual(len(the_app.stack_service.services), 1)
 
     def test_holdonto(self):
         """
@@ -141,9 +164,14 @@ class TestWsgiApp(unittest.TestCase):
         will the response from the StackInABoxService by directly calling into
         the StackInAWSGI handler
         """
-        the_app = App([HelloService()])
+        the_app = App([HelloService])
+        self.helper_make_session(the_app)
         the_app.StackInABoxUriUpdate('localhost')
-        environment = make_environment(self, method='GET', path=u'/hello/')
+        environment = make_environment(
+            self,
+            method='GET',
+            path=u'{0}/hello/'.format(self.session_id_uri)
+        )
 
         request = Request(environment)
         response = Response()
@@ -158,9 +186,14 @@ class TestWsgiApp(unittest.TestCase):
         will the response from the StackInABoxService by into StackInAWSGI as
         a WSGI Callable per PEP-3333.
         """
-        the_app = App([HelloService()])
+        the_app = App([HelloService])
+        self.helper_make_session(the_app)
         the_app.StackInABoxUriUpdate('localhost')
-        environment = make_environment(self, method='GET', path=u'/hello/')
+        environment = make_environment(
+            self,
+            method='GET',
+            path=u'{0}/hello/'.format(self.session_id_uri)
+        )
 
         wsgi_mock = WsgiMock()
         response_body = ''.join(the_app(environment, wsgi_mock))

--- a/stackinawsgi/test/test_wsgi_request.py
+++ b/stackinawsgi/test/test_wsgi_request.py
@@ -24,6 +24,14 @@ class TestWsgiRequest(unittest.TestCase):
         self.environment = make_environment(self)
         self.environment_https = make_environment(self, url_scheme='https')
 
+        self.example_headers = {
+            'x-example': 'here'
+        }
+        self.environment_headers = make_environment(
+            self,
+            headers=self.example_headers
+        )
+
     def tearDown(self):
         """
         Test Teardown
@@ -192,4 +200,16 @@ class TestWsgiRequest(unittest.TestCase):
         self.assertEqual(
             url,
             u"http://localhost/?happy=days"
+        )
+
+    def test_headers(self):
+        """
+        Validate the construction of headers
+        """
+        request = Request(self.environment_headers)
+        self.assertEqual(len(request.headers), 1)
+        self.assertIn('x-example', request.headers)
+        self.assertEqual(
+            request.headers['x-example'],
+            self.example_headers['x-example']
         )

--- a/stackinawsgi/test/test_wsgi_request.py
+++ b/stackinawsgi/test/test_wsgi_request.py
@@ -1,8 +1,9 @@
 """
 Stack-In-A-WSGI: stackinawsgi.wsgi.request.Request testing
 """
-
 import unittest
+
+import ddt
 
 from stackinawsgi.wsgi.request import Request
 from stackinawsgi.test.helpers import (
@@ -10,6 +11,7 @@ from stackinawsgi.test.helpers import (
 )
 
 
+@ddt.ddt
 class TestWsgiRequest(unittest.TestCase):
     """
     Test the interaction of StackInAWSGI's Request object
@@ -37,6 +39,20 @@ class TestWsgiRequest(unittest.TestCase):
         Test Teardown
         """
         pass
+
+    @ddt.unpack
+    @ddt.data(
+        (None, u'/'),
+        ('/', u'/'),
+        ('/hello', u'/hello'),
+        ('/hello/', u'/hello')
+    )
+    def test_get_path(self, url, expected_url):
+        """
+        Test get_path normalization
+        """
+        result = Request.get_path(url)
+        self.assertEqual(result, expected_url)
 
     def test_construction(self):
         """

--- a/stackinawsgi/wsgi/app.py
+++ b/stackinawsgi/wsgi/app.py
@@ -129,7 +129,7 @@ class App(object):
             request.method,
             request,
             request.url,
-            response.headers
+            request.headers
         )
         response.from_stackinabox(
             result[0],

--- a/stackinawsgi/wsgi/app.py
+++ b/stackinawsgi/wsgi/app.py
@@ -4,9 +4,13 @@ Stack-In-A-WSGI Application
 from __future__ import absolute_import
 
 import logging
+from collections import Iterable
 
 from .request import Request
 from .response import Response
+
+from stackinawsgi.session.service import StackInAWsgiSessionManager
+from stackinawsgi.admin.admin import StackInAWsgiAdmin
 
 from stackinabox.services.service import StackInABoxService
 from stackinabox.stack import StackInABox
@@ -28,17 +32,43 @@ class App(object):
             StackInABox.
         """
         self.stackinabox = StackInABox()
+        self.stack_service = StackInAWsgiSessionManager()
+        self.admin_service = StackInAWsgiAdmin(
+            self.stack_service,
+            'http://localhost/stackinabox/'
+        )
+        self.stackinabox.register(self.admin_service)
+        self.stackinabox.register(self.stack_service)
 
+        def __check_service(service_object):
+            """
+            Simple wrapper to check whether an object provide by the caller is
+            a StackInABoxService by creating an instance
+            """
+            svc = service_object()
+            if not isinstance(svc, StackInABoxService):
+                raise TypeError(
+                    "Service is not a Stack-In-A-Box Service"
+                )
+
+        # if the caller does not provide any services then just log it
+        # to keep from user confusion
         if services is not None:
-            # for each StackInABox Service in the configuration,
-            # register with StackInABox
-            for service in services:
-                if isinstance(service, StackInABoxService):
+
+            # Allow the caller to provide either an iterable of services to
+            # to provide to the session or to provide a single service object
+            if isinstance(services, Iterable):
+                # for each service verify it is a StackInABoxService
+                for service in services:
+                    __check_service(service)
                     self.RegisterWithStackInABox(service)
-                else:
-                    raise TypeError(
-                        "Service is not a Stack-In-A-Box Service"
-                    )
+
+            else:
+                # if it's not an iterable - e.g a single object - then
+                # just check the variable itself
+                __check_service(services)
+                self.RegisterWithStackInABox(services)
+
         else:
             logger.debug(
                 "No services registered on initialization"
@@ -51,13 +81,13 @@ class App(object):
         :param :obj:`StackInABoxService` service: the service to register with
             StackInABox
         """
-        self.stackinabox.register(service)
+        self.stack_service.register_service(service)
 
-    def ResetStackInABox(self):
+    def ResetStackInABox(self, session_uuid):
         """
         Reset StackInABox to its default state
         """
-        self.stackinabox.reset()
+        self.stack_service.reset_session(session_uuid)
 
     def StackInABoxHoldOnto(self, name, obj):
         """
@@ -92,6 +122,9 @@ class App(object):
         :param :obj:`Response` response: the :obj:`Response` object to use
             for the output
         """
+        # Parse the URL and determine where it's going
+        # /stackinabox/<session>/<service>/<normal user path>
+        # /admin for StackInAWSGI administrative functionality
         result = self.stackinabox.call(
             request.method,
             request,

--- a/stackinawsgi/wsgi/request.py
+++ b/stackinawsgi/wsgi/request.py
@@ -57,6 +57,14 @@ class Request(object):
         else:
             self.query = None
 
+        self.headers = {}
+        # build out the headers
+        for k, v in self.environment.items():
+            env_key = k.upper()
+            if env_key.startswith('HTTP_'):
+                header_key = k[len('HTTP_'):]
+                self.headers[header_key] = v
+
     @property
     def url(self):
         """

--- a/stackinawsgi/wsgi/request.py
+++ b/stackinawsgi/wsgi/request.py
@@ -1,12 +1,17 @@
 """
 Stack-In-A-WSGI Request Model
 """
+import logging
+
 import six
 
 if six.PY2:
     from urllib import quote
 else:
     from urllib.parse import quote
+
+
+logger = logging.getLogger(__name__)
 
 
 class Request(object):
@@ -64,6 +69,14 @@ class Request(object):
             if env_key.startswith('HTTP_'):
                 header_key = k[len('HTTP_'):]
                 self.headers[header_key] = v
+                logger.debug(
+                    'Headers[{0} -> {1}] = {2} -> {3}'.format(
+                        k,
+                        header_key,
+                        v,
+                        self.headers[header_key]
+                    )
+                )
 
     @property
     def url(self):


### PR DESCRIPTION
Refactor from the initial POC to a usable service set that allows one to dynamically manage sessions for use (create, reset, destroy).
- resetting a session will destroy then create a new session with the same session id
- `StackInABoxService`s must be specified by type and will be auto-instantiated when a session is created
- 100% code coverage
- adds an admin interface as `/admin/` where the following operations can be done:
  - POST - creates a session
  - PUT - resets a session
  - DELETE - deletes a session
- sessions are available under `/stackinabox/<session-id>/`
