### PR TITLE
Bug Fix: Admin Base URI update

### DIFF
--- a/stackinawsgi/admin/admin.py
+++ b/stackinawsgi/admin/admin.py
@@ -67,7 +67,6 @@ class StackInAWsgiAdmin(StackInABoxService):
             )
         )
 
-
     def helper_get_session_id(self, headers):
         """
         Helper to retrieve the session id or build a new one

--- a/stackinawsgi/admin/admin.py
+++ b/stackinawsgi/admin/admin.py
@@ -27,13 +27,7 @@ class StackInAWsgiAdmin(StackInABoxService):
         """
         super(StackInAWsgiAdmin, self).__init__('admin')
         self.manager = session_manager
-        if base_uri.startswith('/'):
-            self.base_uri = base_uri[1:]
-        else:
-            self.base_uri = base_uri
-
-        if self.base_uri.endswith('/'):
-            self.base_uri = self.base_uri[:-1]
+        self.base_uri = base_uri
 
         self.register(
             StackInABoxService.DELETE, '/', StackInAWsgiAdmin.remove_session
@@ -47,6 +41,32 @@ class StackInAWsgiAdmin(StackInABoxService):
         self.register(
             StackInABoxService.GET, '/', StackInAWsgiAdmin.get_session_info
         )
+
+    @property
+    def base_uri(self):
+        """
+        Base URI of the WSGI App
+        """
+        return self.__base_uri
+
+    @base_uri.setter
+    def base_uri(self, value):
+        """
+        Update the Base URI of the WSGI App
+        """
+        if value.startswith('/'):
+            value = value[1:]
+
+        if value.endswith('/'):
+            value = value[:-1]
+
+        self.__base_uri = value
+        logger.debug(
+            'Received Base URI: {0}'.format(
+                self.__base_uri
+            )
+        )
+
 
     def helper_get_session_id(self, headers):
         """

--- a/stackinawsgi/test/test_admin_admin.py
+++ b/stackinawsgi/test/test_admin_admin.py
@@ -46,7 +46,17 @@ class TestSessionManager(unittest.TestCase):
         self.assertEqual(id(self.manager), id(admin.manager))
         self.assertTrue(admin.base_uri.startswith(self.base_uri))
 
-    def test_construction_alternate_url(self):
+    def test_property_base_uri_with_no_slash(self):
+        """
+        test basic construction of the admin interface
+        """
+        base_uri = 'hello'
+        admin = StackInAWsgiAdmin(self.manager, base_uri)
+        self.assertIsInstance(admin, StackInABoxService)
+        self.assertEqual(id(self.manager), id(admin.manager))
+        self.assertTrue(admin.base_uri.startswith(base_uri))
+
+    def test_property_base_uri_start_with_slash(self):
         """
         test basic construction of the admin interface
         """
@@ -55,6 +65,15 @@ class TestSessionManager(unittest.TestCase):
         self.assertIsInstance(admin, StackInABoxService)
         self.assertEqual(id(self.manager), id(admin.manager))
         self.assertTrue(admin.base_uri.startswith(base_uri[1:]))
+
+    def test_property_base_uri_ends_with_slash(self):
+        """
+        """
+        base_uri = 'hello/'
+        admin = StackInAWsgiAdmin(self.manager, base_uri)
+        self.assertIsInstance(admin, StackInABoxService)
+        self.assertEqual(id(self.manager), id(admin.manager))
+        self.assertTrue(admin.base_uri.startswith(base_uri[:-1]))
 
     def test_helper_get_session_id(self):
         """

--- a/stackinawsgi/wsgi/app.py
+++ b/stackinawsgi/wsgi/app.py
@@ -112,6 +112,7 @@ class App(object):
         Update StackInABox to use a new URI value.
         """
         self.stackinabox.base_url = uri
+        self.admin_service.base_uri = uri
 
     def CallStackInABox(self, request, response):
         """


### PR DESCRIPTION
Admin module was not getting it's base url used for reporting the session location when it was changed in the main app. Fixes another part of the issue in #11 .
